### PR TITLE
Bump `ghostwriter/container` from `5.0.0` to `5.0.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^1.0.0",
-        "ghostwriter/container": "^5.0.0",
+        "ghostwriter/container": "^5.0.1",
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/option": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ab4502eed8ef4c71c75f65d80ab3e34",
+    "content-hash": "01ff17b1c5a87ba2e3516b4f35313941",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -256,23 +256,27 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "e92b51b825b9b3883bfab6d1077e050bd8035d78"
+                "reference": "e77a71185922b5a67a0219de6acce2d5be8496f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/e92b51b825b9b3883bfab6d1077e050bd8035d78",
-                "reference": "e92b51b825b9b3883bfab6d1077e050bd8035d78",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/e77a71185922b5a67a0219de6acce2d5be8496f2",
+                "reference": "e77a71185922b5a67a0219de6acce2d5be8496f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": "^8.4"
+            },
+            "provide": {
+                "psr/container-implementation": "*"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "dev-main",
+                "psr/container": "^1.1 || ^2.0"
             },
             "type": "library",
             "autoload": {
@@ -282,7 +286,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -310,7 +314,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-21T19:09:09+00:00"
+            "time": "2025-03-18T19:43:29+00:00"
         },
         {
             "name": "ghostwriter/event-dispatcher",


### PR DESCRIPTION
Bumps `ghostwriter/container` from `5.0.0` to `5.0.1`.

- Update `composer.json`
- Update `composer.lock`