### PR TITLE
Bump `ghostwriter/case-converter` from `2.0.0` to `2.1.0`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,24 +8,25 @@
     "packages": [
         {
             "name": "ghostwriter/case-converter",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/case-converter.git",
-                "reference": "e3479766f945d78c3e6a64569d8293cf6fe7b80e"
+                "reference": "21ea17ef7518e2241b504895752a1957f5284cc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/e3479766f945d78c3e6a64569d8293cf6fe7b80e",
-                "reference": "e3479766f945d78c3e6a64569d8293cf6fe7b80e",
+                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/21ea17ef7518e2241b504895752a1957f5284cc3",
+                "reference": "21ea17ef7518e2241b504895752a1957f5284cc3",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.4"
+                "php": "^8.4"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/container": "^5.0.1"
             },
             "type": "library",
             "autoload": {
@@ -35,7 +36,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -75,7 +76,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-06T12:07:45+00:00"
+            "time": "2025-03-21T01:13:07+00:00"
         },
         {
             "name": "ghostwriter/clock",
@@ -7655,7 +7656,7 @@
     "platform": {
         "php": "^8.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.4.999"
     },


### PR DESCRIPTION
Bumps `ghostwriter/case-converter` from `2.0.0` to `2.1.0`.

- Update `composer.lock`