### PR TITLE
Update ghostwriter/coding-standard to version dev-main#5a3b190

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,24 +39,24 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
-        "ghostwriter/case-converter": "^2.1.0",
-        "ghostwriter/clock": "^3.0.1",
-        "ghostwriter/collection": "^2.0.0",
-        "ghostwriter/config": "^1.0.0",
-        "ghostwriter/container": "^5.0.1",
-        "ghostwriter/event-dispatcher": "^5.0.3",
-        "ghostwriter/json": "^3.0.0",
-        "ghostwriter/option": "^2.0.0",
-        "ghostwriter/result": "^2.0.0",
-        "ghostwriter/shell": "^0.1.0",
-        "ghostwriter/uuid": "^1.0.3"
+        "ghostwriter/case-converter": "~2.1.0",
+        "ghostwriter/clock": "~3.0.1",
+        "ghostwriter/collection": "~2.0.0",
+        "ghostwriter/config": "~1.0.0",
+        "ghostwriter/container": "~5.0.1",
+        "ghostwriter/event-dispatcher": "~5.0.3",
+        "ghostwriter/json": "~3.0.0",
+        "ghostwriter/option": "~2.0.0",
+        "ghostwriter/result": "~2.0.0",
+        "ghostwriter/shell": "~0.1.0",
+        "ghostwriter/uuid": "~1.0.3"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.11",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.11",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8985c3865138960b4bc1ca855a5f98f3",
+    "content-hash": "ec1fed8f373e0813724e4cb564cefa90",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1305,12 +1305,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "bbbd28d5b45f3fb25a76595c15e8f69e3ddcab03"
+                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/bbbd28d5b45f3fb25a76595c15e8f69e3ddcab03",
-                "reference": "bbbd28d5b45f3fb25a76595c15e8f69e3ddcab03",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5a3b19053dc74511910d5f81bb41e8422c6842c8",
+                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8",
                 "shasum": ""
             },
             "require": {
@@ -1467,7 +1467,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-19T11:55:28+00:00"
+            "time": "2025-09-19T12:54:01+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#bbbd28d` to `dev-main#5a3b190`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`