### PR TITLE
Update boundwize/structarmed to version 0.6.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.9",
+        "boundwize/structarmed": "^0.6.10",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9160f9a3119e8254b36a265d17b4a2db",
+    "content-hash": "13b81496ecea5c2dbae3d20ede6b6405",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -897,16 +897,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.9",
+            "version": "0.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "3c2f00553b55c98de1966d75d914ea27a35bcf7a"
+                "reference": "893d7fb54627be9bfc127fbddaaaa1921fd026aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3c2f00553b55c98de1966d75d914ea27a35bcf7a",
-                "reference": "3c2f00553b55c98de1966d75d914ea27a35bcf7a",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/893d7fb54627be9bfc127fbddaaaa1921fd026aa",
+                "reference": "893d7fb54627be9bfc127fbddaaaa1921fd026aa",
                 "shasum": ""
             },
             "require": {
@@ -955,7 +955,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.9"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.10"
             },
             "funding": [
                 {
@@ -963,7 +963,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T08:16:03+00:00"
+            "time": "2026-05-19T10:47:01+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.9` to `0.6.10`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`